### PR TITLE
Actualización de la variable idioma

### DIFF
--- a/build.properties
+++ b/build.properties
@@ -50,7 +50,7 @@ solr.server=http://localhost/solr
 solr.multicorePrefix=
 
 # Default language for metadata values
-default.language = es_PE
+default.language = es
 
 ##########################
 # DATABASE CONFIGURATION #

--- a/build.properties
+++ b/build.properties
@@ -79,13 +79,13 @@ db.password=dspace
 db.schema = 
 
 # Maximum number of DB connections in pool
-db.maxconnections = 30
+db.maxconnections = 500
 
 # Maximum time to wait before giving up if all connections in pool are busy (milliseconds)
-db.maxwait = 5000
+db.maxwait = 10000
 
 # Maximum number of idle connections in pool (-1 = unlimited)
-db.maxidle = -1
+db.maxidle = 1000
 
 # Determine if prepared statement should be cached. (default is true)
 db.statementpool = true


### PR DESCRIPTION
Se cambió el valor de la variable `default.language` de `es_PE` a `es`